### PR TITLE
include interpreter_python default

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+interpreter_python = /usr/bin/python3


### PR DESCRIPTION
Hi!
First of all thank you for all of the work put on this repo.

This is something that solved a problem that I had when trying to install and configure a new computer to use Tidal through your ansible stuff. I don't know if this solution is valid for general use and I'm a total beginner in Ansible.

I was getting a warning follow by an error:

```
TASK [Gathering Facts] ***********************************************************************************************************************************************************************
[WARNING]: Platform linux on host localhost is using the discovered Python interpreter at /usr/bin/python3.9, but future installation of another Python interpreter could change the meaning
of that path. See https://docs.ansible.com/ansible/2.10/reference_appendices/interpreter_discovery.html for more information.
```
and then this:
```
TASK [roles/tidal : install supercollider dependencies (debian)] *****************************************************************************************************************************
[WARNING]: Updating cache and auto-installing missing dependency: python3-apt
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Could not import python modules: apt, apt_pkg. Please install python3-apt package."}
```
Well, `python3-apt` is very much installed. Trying to understand the warnings I guessed that Ansible was trying to use the wrong Python interpreter, so I made it use the one I found more general.

That's it. I don't know if this is the best way of doing it. Maybe this could be a note in the README.

best regards
Gil